### PR TITLE
add `From` `BTreeSet` conversion  for `Clause` & `Component` to support dynamic sized `DCLabel`s

### DIFF
--- a/src/dclabel/clause.rs
+++ b/src/dclabel/clause.rs
@@ -2,7 +2,6 @@ use serde::{Serialize, Deserialize};
 
 use super::Principal;
 use alloc::collections::BTreeSet;
-use alloc::vec::Vec;
 
 #[derive(Eq, PartialEq, PartialOrd, Ord, Debug, Clone, Serialize, Deserialize)]
 pub struct Clause(pub BTreeSet<Principal>);
@@ -13,14 +12,6 @@ impl Clause {
     }
 
     pub fn new<P: Into<Principal> + Clone, const N: usize>(principals: [P; N]) -> Clause {
-        let mut result = BTreeSet::new();
-        for p in principals.iter() {
-            result.insert(p.clone().into());
-        }
-        Self(result)
-    }
-
-    pub fn new_from_vec<P: Into<Principal> + Clone>(principals: Vec<P>) -> Clause {
         let mut result = BTreeSet::new();
         for p in principals.iter() {
             result.insert(p.clone().into());
@@ -40,9 +31,9 @@ impl<P: Into<Principal> + Clone, const N: usize> From<[P; N]> for Clause {
     }
 }
 
-impl<P: Into<Principal> + Clone> From<Vec<P>> for Clause {
-    fn from(principals: Vec<P>) -> Clause {
-        Clause::new_from_vec(principals)
+impl From<BTreeSet<Principal>> for Clause {
+    fn from(principals: BTreeSet<Principal>) -> Clause {
+        Clause(principals)
     }
 }
 

--- a/src/dclabel/component.rs
+++ b/src/dclabel/component.rs
@@ -2,6 +2,7 @@ use serde::{Serialize, Deserialize};
 
 use super::clause::Clause;
 use alloc::collections::BTreeSet;
+use alloc::vec::Vec;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum Component {
@@ -11,6 +12,14 @@ pub enum Component {
 
 impl Component {
     pub fn formula<C: Into<Clause> + Clone, const N: usize>(clauses: [C; N]) -> Component {
+        let mut result = BTreeSet::new();
+        for c in clauses.iter() {
+            result.insert(c.clone().into());
+        }
+        Component::DCFormula(result)
+    }
+
+    pub fn formula_from_vec<C: Into<Clause> + Clone>(clauses: Vec<C>) -> Component {
         let mut result = BTreeSet::new();
         for c in clauses.iter() {
             result.insert(c.clone().into());
@@ -79,6 +88,12 @@ impl Component {
 impl<C: Into<Clause> + Clone, const N: usize> From<[C; N]> for Component {
     fn from(clauses: [C; N]) -> Component {
         Component::formula(clauses)
+    }
+}
+
+impl<C: Into<Clause> + Clone> From<Vec<C>> for Component {
+    fn from(clauses: Vec<C>) -> Component {
+        Component::formula_from_vec(clauses)
     }
 }
 

--- a/src/dclabel/component.rs
+++ b/src/dclabel/component.rs
@@ -92,6 +92,12 @@ impl From<bool> for Component {
     }
 }
 
+impl From<BTreeSet<Clause>> for Component {
+    fn from(clauses: BTreeSet<Clause>) -> Component {
+        Component::DCFormula(clauses)
+    }
+}
+
 impl core::ops::BitAnd for Component {
     type Output = Component;
     fn bitand(self, rhs: Self) -> Component {

--- a/src/dclabel/component.rs
+++ b/src/dclabel/component.rs
@@ -2,7 +2,6 @@ use serde::{Serialize, Deserialize};
 
 use super::clause::Clause;
 use alloc::collections::BTreeSet;
-use alloc::vec::Vec;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum Component {
@@ -12,14 +11,6 @@ pub enum Component {
 
 impl Component {
     pub fn formula<C: Into<Clause> + Clone, const N: usize>(clauses: [C; N]) -> Component {
-        let mut result = BTreeSet::new();
-        for c in clauses.iter() {
-            result.insert(c.clone().into());
-        }
-        Component::DCFormula(result)
-    }
-
-    pub fn formula_from_vec<C: Into<Clause> + Clone>(clauses: Vec<C>) -> Component {
         let mut result = BTreeSet::new();
         for c in clauses.iter() {
             result.insert(c.clone().into());
@@ -88,12 +79,6 @@ impl Component {
 impl<C: Into<Clause> + Clone, const N: usize> From<[C; N]> for Component {
     fn from(clauses: [C; N]) -> Component {
         Component::formula(clauses)
-    }
-}
-
-impl<C: Into<Clause> + Clone> From<Vec<C>> for Component {
-    fn from(clauses: Vec<C>) -> Component {
-        Component::formula_from_vec(clauses)
     }
 }
 


### PR DESCRIPTION
The PR is for supporting dynamic sized `DCLabel`s.
One use case is to create `DCLabel`s from command-line inputs.

The changes include:
1. `From<BTreeSet<Clause>> for Component` implementation
2. `From<BTreeSet<Principal>> for Clause` implementation
3. Removed the old `From<Vec<P>> for Clause`.